### PR TITLE
Allow Triggerable to be globally disabled

### DIFF
--- a/lib/triggerable.rb
+++ b/lib/triggerable.rb
@@ -30,6 +30,18 @@ require "triggerable/actions/lambda_action"
 module Triggerable
   extend ActiveSupport::Concern
 
+  def self.enable!
+    @disabled = false
+  end
+
+   def self.disable!
+    @disabled = true
+  end
+
+  def self.enabled?
+    !@disabled
+  end
+
   included do
     CALLBACKS = [
       :before_create,
@@ -51,6 +63,7 @@ module Triggerable
     private
 
     def run_triggers callback
+      return unless Triggerable.enabled?
       Engine.triggers_for(self, callback).each { |t| t.execute!(self) }
       true
     end

--- a/lib/triggerable/engine.rb
+++ b/lib/triggerable/engine.rb
@@ -25,6 +25,7 @@ module Triggerable
 
     def self.run_automations interval
       self.interval = interval
+      return unless Triggerable.enabled?
       automations.each(&:execute!)
     end
 

--- a/spec/integration/actions_spec.rb
+++ b/spec/integration/actions_spec.rb
@@ -38,4 +38,26 @@ describe 'Actions' do
     expect(TestTask.all[-2].kind).to eq('follow up')
     expect(TestTask.all.last.kind).to eq('follow up')
   end
+
+  describe 'when Triggerable is disabled' do
+    before do
+      TestTask.trigger on: :after_create,
+                       if: { status: 'solved' },
+                       do: :create_follow_up
+    end
+
+    after { Triggerable.enable! }
+
+    it 'it does not run actions' do
+      expect {
+        TestTask.create status: 'solved'
+      }.to change(TestTask, :count).by(2)
+
+      Triggerable.disable!
+
+      expect {
+        TestTask.create status: 'solved'
+      }.to change(TestTask, :count).by(1)
+    end
+  end
 end

--- a/spec/integration/short_syntax_spec.rb
+++ b/spec/integration/short_syntax_spec.rb
@@ -89,4 +89,26 @@ describe 'Short syntax' do
     task.update_attributes status: 'solved'
     expect(task.status).to eq('confirmed')
   end
+
+  context 'when Triggerable is disabled' do
+    before do
+      TestTask.trigger on: :after_create, if: {status: ['solved']} do
+        TestTask.create kind: 'follow up'
+      end
+    end
+
+    after { Triggerable.enable! }
+
+    it 'does not run actions' do
+      expect {
+        TestTask.create status: 'solved'
+      }.to change(TestTask, :count).by(2)
+
+      Triggerable.disable!
+
+      expect {
+        TestTask.create status: 'solved'
+      }.to change(TestTask, :count).by(1)
+    end
+  end
 end


### PR DESCRIPTION
This is especially useful for tests in projects that use Triggerable, so that we can run factories to set up data in a specific way without triggers interfering with them.